### PR TITLE
update installation instructions for oneclient

### DIFF
--- a/source/clients.rst
+++ b/source/clients.rst
@@ -77,7 +77,7 @@ The following variables have to be exported in the container:
 .. code-block:: console
 
    docker run -it --privileged centos:7 /bin/bash
-   root@81dbd7e84438 /]# curl -sS  http://get.onedata.org/oneclient.sh | bash
+   root@81dbd7e84438 /]# curl -sS  http://get.onedata.org/oneclient-1902.sh | bash
    # (...)
    Complete!
    Installation has been completed successfully.
@@ -117,7 +117,7 @@ The following variables have to be exported to be used in the container:
 
    export ONECLIENT_ACCESS_TOKEN=<ACCESS_TOKEN_FROM_ONEZONE>
    export ONECLIENT_PROVIDER_HOST=plg-cyfronet-01.datahub.egi.eu
-   docker run -it --privileged -e ONECLIENT_ACCESS_TOKEN=$ONECLIENT_ACCESS_TOKEN -e ONECLIENT_PROVIDER_HOST=$ONECLIENT_PROVIDER_HOST onedata/oneclient:18.02.0-rc13
+   docker run -it --privileged -e ONECLIENT_ACCESS_TOKEN=$ONECLIENT_ACCESS_TOKEN -e ONECLIENT_PROVIDER_HOST=$ONECLIENT_PROVIDER_HOST onedata/oneclient:19.02.0-rc2
    Connecting to provider 'plg-cyfronet-01.datahub.egi.eu:443' using session ID: '4138963898952098752'...
    Getting configuration...
    Oneclient has been successfully mounted in '/mnt/oneclient'
@@ -156,7 +156,7 @@ mount manually the Onedata spaces.
 
    export ONECLIENT_ACCESS_TOKEN=<ACCESS_TOKEN_FROM_ONEZONE>
    export ONECLIENT_PROVIDER_HOST=plg-cyfronet-01.datahub.egi.eu
-   docker run -it --privileged -e ONECLIENT_ACCESS_TOKEN=$ONECLIENT_ACCESS_TOKEN -e ONECLIENT_PROVIDER_HOST=$ONECLIENT_PROVIDER_HOST -v $PWD:/mnt/src --entrypoint bash onedata/oneclient:18.02.0-rc13
+   docker run -it --privileged -e ONECLIENT_ACCESS_TOKEN=$ONECLIENT_ACCESS_TOKEN -e ONECLIENT_PROVIDER_HOST=$ONECLIENT_PROVIDER_HOST -v $PWD:/mnt/src --entrypoint bash onedata/oneclient:19.02.0-rc2
    root@aca612a84fb4:/tmp# oneclient /mnt/oneclient
    Connecting to provider 'plg-cyfronet-01.datahub.egi.eu:443' using session ID: '1641165171427694510'...
    Getting configuration...
@@ -182,7 +182,7 @@ The following variables have to be exported:
 
 .. code-block:: console
 
-   curl -sS http://get.onedata.org/oneclient.sh | bash
+   curl -sS http://get.onedata.org/oneclient-1902.sh | bash
    export ONECLIENT_ACCESS_TOKEN=<ACCESS_TOKEN_FROM_ONEZONE>
    export ONECLIENT_PROVIDER_HOST=plg-cyfronet-01.datahub.egi.eu
    mkdir /tmp/space
@@ -203,7 +203,7 @@ The following variables have to be exported:
    vagrant init ubuntu/xenial64
    vagrant up
    vagrant ssh
-   curl -sS http://get.onedata.org/oneclient.sh | bash
+   curl -sS http://get.onedata.org/oneclient-1902.sh | bash
    export ONECLIENT_ACCESS_TOKEN=<ACCESS_TOKEN_FROM_ONEZONE>
    export ONECLIENT_PROVIDER_HOST=plg-cyfronet-01.datahub.egi.eu
    mkdir /tmp/space


### PR DESCRIPTION
# Summary 

The oneprovider and onezone behing DataHub are  running a newer version (19.02.0.RC2) while the oneclient installed by default is still 18.02 and not compatible with the new version. 

I changed the installation instructions to use the 1902 version of the installation script, and also the version of the docker images to use


